### PR TITLE
Fix build definition for sbt 0.13.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ parallelExecution in Test := false
 ////////////////////
 // publishing
 
-pomExtra :=
+pomExtra := {
   <url>http://nbronson.github.com/scala-stm/</url>
   <licenses>
     <license>
@@ -42,6 +42,7 @@ pomExtra :=
       <email>ngbronson@gmail.com</email>
     </developer>
   </developers>
+}
 
 publishMavenStyle := true
 


### PR DESCRIPTION
Without the braces, sbt 0.13.8 chockes on the build definition:

```
[error] [/Users/luc/scala/scala-stm/build.sbt]:46: ';' expected but 'true' found.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? lucmac:scala-stm luc$ 
```

cc @jsuereth @eed3si9n
