### PR TITLE
removed deprecated scala.concurrent.forkjoin.LinkedTransferQueue

### DIFF
--- a/src/test/scala/scala/concurrent/stm/CallbackSuite.scala
+++ b/src/test/scala/scala/concurrent/stm/CallbackSuite.scala
@@ -322,7 +322,7 @@ class CallbackSuite extends FunSuite {
     val failure = Ref(null : Throwable)
 
     val x = Ref(0)
-    val notifier = new scala.concurrent.forkjoin.LinkedTransferQueue[Int]()
+    val notifier = new java.util.concurrent.LinkedTransferQueue[Int]()
     val EOF = -1
 
     for (_ <- 1 to numThreads) {

--- a/src/test/scala/scala/concurrent/stm/CommitBarrierSuite.scala
+++ b/src/test/scala/scala/concurrent/stm/CommitBarrierSuite.scala
@@ -2,11 +2,10 @@
 
 package scala.concurrent.stm
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{LinkedTransferQueue, TimeUnit}
 
 import org.scalatest.FunSuite
 
-import scala.concurrent.forkjoin.LinkedTransferQueue
 import scala.concurrent.stm.skel.SimpleRandom
 import scala.util.control.Breaks
 


### PR DESCRIPTION
addresses #56 again.